### PR TITLE
docs: fix duplicate case in playMedia example and remove TODO comment

### DIFF
--- a/typescript/types/types/index.md
+++ b/typescript/types/types/index.md
@@ -135,7 +135,6 @@ console.log(user[key_2]); // 30
 
 Пример:
 
-TODO: подумать над нормальным примером
 
 ```typescript
 let unassignedVariable: undefined = undefined;
@@ -227,7 +226,7 @@ enum TypeMedia {
 
 function playMedia(type: TypeMedia): void {
   switch (type) {
-    case TypeMedia.Video:
+    case TypeMedia.Image:
       console.log('Отображение изображения');
       // Логика для отображения изображения
       break;


### PR DESCRIPTION
Hi!

Thanks for the helpful article on using types in TypeScript! typescript/types/types/index.md


While I was reading it, I noticed a small mistake in the `playMedia` function example on the line 230
The `case TypeMedia.Video` appears twice:

```ts
function playMedia(type: TypeMedia): void {
  switch (type) {
    case TypeMedia.Video:
      console.log('Отображение изображения');
      break;
    case TypeMedia.Video:
      console.log('Воспроизведение видео');
      break;
    case TypeMedia.Audio:
      console.log('Воспроизведение аудио');
      break;
    default:
      console.log(`Неизвестный тип медиафайла: ${медиафайл.тип}`);
  }
}
```

I think that the first case might be a typo I guess it was meant to be TypeMedia.Image

Also on the line 138 there's a comment that have to be deleted I guess, "`TODO: подумать над нормальным примером`"

Thanks for the materials it helps me to prepare for my upcoming interview!
